### PR TITLE
Support declaring resource servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ pre-configured.
   Create a Cognito User Pool with pre-configured best practices.
   Create Cognito User Pool Clients.
   Create a Cognito User Pool Domain.
+  Create Cognito User Pool Resource Servers as associated scopes.
 
 - *Features not yet implemented*:
   [`cognito_user_group`](https://www.terraform.io/docs/providers/aws/r/cognito_user_group.html)
-  [`cognito_resource_server`](https://www.terraform.io/docs/providers/aws/r/cognito_resource_server.html)
 
 ## Getting Started
 
@@ -404,6 +404,36 @@ for details and use-cases.
   The ARN of an ISSUED ACM certificate in us-east-1 for a custom domain.
   Default is not to use a custom domain.
 
+#### Cognito User Pool Resource Servers
+
+- **`resource_servers`**: *(Optional `list(resource_server)`)
+
+  A list of objects with resource server declarations.
+  Default is []
+
+  **Example:**
+
+  A resource server declaration with scopes. For details see the [Terraform AWS Cognito Resource Server Docs]
+
+  ```hcl
+  resource_servers = [
+    {
+      identifier = "https://api.resourceserver.com"
+      name       = "API"
+      scopes     = [
+        {
+          scope_name = "users:read"
+          scope_description = "Read user data"
+        },
+        {
+          scope_name = "users:write"
+          scope_description = "Write user data"
+        }
+      ]
+    }
+  ]
+  ```
+
 #### Cognito User Pool Clients
 
 - **`clients`**: *(Optional `list(client)`)*
@@ -640,3 +670,4 @@ Copyright &copy; 2020 [Mineiros GmbH][homepage]
 [Cognito User Pools]: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html
 [attributes docs]: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html
 [Terraform AWS Cognito User Pool Client Docs]: https://www.terraform.io/docs/providers/aws/r/cognito_user_pool_client.html
+[Terraform AWS Cognito Resource Server Docs]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_resource_server

--- a/main.tf
+++ b/main.tf
@@ -243,6 +243,10 @@ resource "aws_cognito_user_pool_client" "client" {
   }
 
   enable_token_revocation = each.value.enable_token_revocation
+
+  depends_on = [
+    aws_cognito_resource_server.resource_server
+  ]
 }
 
 resource "aws_cognito_user_pool_domain" "domain" {

--- a/resource-server.tf
+++ b/resource-server.tf
@@ -1,0 +1,21 @@
+resource "aws_cognito_resource_server" "resource_server" {
+  for_each = { for resource in var.resource_servers :
+    resource.identifier => {
+      name   = try(resource.name, null)
+      scopes = try(resource.scopes, [])
+    }
+    if can(resource.identifier)
+  }
+
+  identifier   = each.key
+  name         = each.value.name
+  user_pool_id = aws_cognito_user_pool.user_pool[0].id
+
+  dynamic "scope" {
+    for_each = each.value.scopes
+    content {
+      scope_name        = scope.value.scope_name
+      scope_description = scope.value.scope_description
+    }
+  }
+}

--- a/test/user-pool/main.tf
+++ b/test/user-pool/main.tf
@@ -21,4 +21,6 @@ module "cognito_user_pool" {
   domain = var.domain
 
   schema_attributes = var.schema_attributes
+  clients           = var.clients
+  resource_servers  = var.resource_servers
 }

--- a/test/user-pool/variables.tf
+++ b/test/user-pool/variables.tf
@@ -35,6 +35,27 @@ variable "domain" {
   default     = "mineiros-test"
 }
 
+variable "resource_servers" {
+  description = "(Optional) A list of objects with resource server definitions."
+  type        = any
+  default = [
+    {
+      identifier = "https://api.resourceserver.com"
+      name       = "API"
+      scopes = [
+        {
+          scope_name        = "users:read",
+          scope_description = "Read user data"
+        },
+        {
+          scope_name        = "users:write"
+          scope_description = "Write user data"
+        }
+      ]
+    }
+  ]
+}
+
 variable "clients" {
   description = "(Optional) A list of objects with the clients definitions."
   type        = any
@@ -42,7 +63,7 @@ variable "clients" {
     {
       name                 = "android-mobile-client"
       read_attributes      = ["email", "email_verified", "preferred_username"]
-      allowed_oauth_scopes = ["email", "openid"]
+      allowed_oauth_scopes = ["email", "openid", "https://api.resourceserver.com/users:read"]
       allowed_oauth_flows  = ["implicit"]
       callback_urls        = ["https://mineiros.io/callback", "https://mineiros.io/anothercallback"]
       default_redirect_uri = "https://mineiros.io/callback"

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,35 @@ variable "allow_admin_create_user_only" {
   default     = true
 }
 
+variable "resource_servers" {
+  description = "(Optional) A list of objects with resource server definitions."
+  type        = any
+
+  # Declare resource servers and associated custom scopes
+  # For details please see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_resource_server
+  #
+  # Example:
+  #
+  # resource_servers = [
+  #   {
+  #     identifier = "https://api.resourceserver.com"
+  #     name       = "API"
+  #     scopes     = [
+  #       {
+  #         scope_name = "users:read"
+  #         scope_description = "Read user data"
+  #       },
+  #       {
+  #         scope_name = "users:write"
+  #         scope_description = "Write user data"
+  #       }
+  #     ]
+  #   }
+  # ]
+
+  default = []
+}
+
 variable "clients" {
   description = "(Optional) A list of objects with the clients definitions."
   type        = any


### PR DESCRIPTION
Adds support for declaring resource servers in Cognito user pools. Addresses issue #54 

* Note that clients are dependent on resource server creation so that custom scopes assigned to app clients can be properly referenced.
* No known breaking changes have been introduced with this PR.