### PR TITLE
user-attribute-update-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ for details and use-cases.
 
   Default is `1`.
 
+  [**`attributes_require_verification_before_update`**](#var-attributes_require_verification_before_update): *(Optional `string`)*<a name="var-attributes_require_verification_before_update"></a>
+  
+  A list of attributes requiring verification before update. If set, the provided value(s) must also be set in auto_verified_attributes. Valid values: email, phone_number. When you update the value of an email or phone number attribute, your user must verify the new value. Until they verify the new value, they can receive messages and sign in with the original value. If you don't turn on this feature, your user can't sign in with that attribute before they verify the new value.
+  
+  Default is `["email"]`.
+
 - [**`allow_software_mfa_token`**](#var-allow_software_mfa_token): *(Optional `bool`)*<a name="var-allow_software_mfa_token"></a>
 
   Boolean whether to enable software token Multi-Factor Authentication (MFA) tokens, such as Time-Based One-Time Password (TOTP). To disable software token MFA when `sms_configuration` is not present, the `mfa_configuration` argument must be set to `OFF` and the `software_token_mfa_configuration` configuration block must be fully removed.

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,10 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   mfa_configuration = var.mfa_configuration
 
+  user_attribute_update_settings {
+    attributes_require_verification_before_update = var.attributes_require_verification_before_update
+  }
+  
   password_policy {
     minimum_length                   = var.password_minimum_length
     require_lowercase                = var.password_require_lowercase

--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ locals {
 }
 
 resource "aws_cognito_user_pool_client" "client" {
-  var.module_enabled ? local.clients : map(object({}))
+  for_each = var.module_enabled ? local.clients : map(object({}))
 
   name = each.key
 

--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ locals {
 }
 
 resource "aws_cognito_user_pool_client" "client" {
-  for_each = var.module_enabled ? local.clients : {}
+  var.module_enabled ? local.clients : map(object({}))
 
   name = each.key
 

--- a/variables.tf
+++ b/variables.tf
@@ -252,6 +252,14 @@ variable "auto_verified_attributes" {
   ]
 }
 
+variable "attributes_require_verification_before_update" {
+  type        = set(string)
+  description = "(Required) A list of attributes requiring verification before update. If set, the provided value(s) must also be set in auto_verified_attributes. Valid values: email, phone_number."
+  default = [
+    "email"
+  ]
+}
+
 variable "account_recovery_mechanisms" {
   type        = any
   description = "(Optional) A list of recovery_mechanisms which are defined by a `name` and its `priority`. Valid values for `name` are veri  fied_email, verified_phone_number, and admin_only."


### PR DESCRIPTION
Prevents instant use of a changed user account without data verification.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-userattributeupdatesettings.html