### PR TITLE
Update README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@
 # Examples for using this Mineiros module
 
 - [complete/] Deploy a Cognito User Pool with custom settings.
-- [user-pool-with-default-settings/] Deploy a Cognito User Pool with custom settings.
+- [user-pool-with-default-settings/] Deploy a Cognito User Pool with default settings.
 
 <!-- References -->
 [complete/]: https://github.com/mineiros-io/terraform-aws-cognito-user-pool/blob/master/examples/complete


### PR DESCRIPTION
### Description
According to this [README.md](https://github.com/mineiros-io/terraform-aws-cognito-user-pool/blob/6f460e6cce3de489d0306aa37a4453fcf5383edc/examples/README.md) file, the second link ([user-pool-with-default-settings/](https://github.com/mineiros-io/terraform-aws-cognito-user-pool/blob/master/examples/user-pool-with-default-settings) ) contains examples of cognito user pool with default settings. But it is wrongly labelled as "Deploy a Cognito User Pool with **custom** settings." 

This needs to be fixed.

### Changes
Original Text => Deploy a Cognito User Pool with custom settings.
Text after fix => Deploy a Cognito User Pool with default settings.

### Issue
https://github.com/mineiros-io/terraform-aws-cognito-user-pool/issues/73