### PR TITLE
Add support for AWS provider v5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ vendor
 
 # Terratest directory used to store temporary data
 .test-data
+.terratest
 
 # Terraform crash log files
 crash.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for AWS provider `v5.x`
+
 ## [0.9.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A [Terraform] module for deploying and managing
 on [Amazon Web Services (AWS)][AWS].
 
 *This module supports Terraform v1.x, v0.15, v0.14, v0.13 as well as v0.12.20 and above
-and is compatible with the Terraform AWS provider v3.50 and above.
+and is compatible with the Terraform AWS provider versions above v3.50 and below v6.0.
 
 
 - [Module Features](#module-features)

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/test/unit-disabled/main.tf
+++ b/test/unit-disabled/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,6 @@ terraform {
   required_version = ">= 0.12.20, < 2.0"
 
   required_providers {
-    aws = ">= 3.50, < 5.0"
+    aws = ">= 3.50, < 6.0"
   }
 }


### PR DESCRIPTION
Primarily bumping the 'up to' version constraint from `< 5.0` to `< 6.0`. Proposing to release the changes as `v0.9.3`!

'Complete' and 'disabled' unit tests passed successfully locally via Docker.
The 'minimal' test is failing due to not being idempotent. However, this is also failing on the current latest changes and could be addressed separately.

Please let me know if any changes are necessary 🙏 Thanks!