### PR TITLE
Fix/multiple app clients issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,7 @@ locals {
 }
 
 resource "aws_cognito_user_pool_client" "client" {
-  for_each = var.module_enabled ? local.clients : []
+  for_each = var.module_enabled ? local.clients : null
 
   name = each.key
 

--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,7 @@ locals {
 }
 
 resource "aws_cognito_user_pool_client" "client" {
-  for_each = var.module_enabled ? local.clients : {}
+  for_each = var.module_enabled ? local.clients : []
 
   name = each.key
 


### PR DESCRIPTION
Fixes following error during `terraform plan` with multiple app-clients defined:

│   on .terraform/modules/console_ui_cognito_user_pool/main.tf line 214, in resource "aws_cognito_user_pool_client" "client":
│  214:   for_each = var.module_enabled ? local.clients : {}
│     ├────────────────
│     │ local.clients is object with 2 attributes
│     │ var.module_enabled is true
│ 
│ The true and false result expressions must have consistent types. The
│ 'true' value includes object attribute "auto-test-app", which is absent in
│ the 'false' value.