### PR TITLE
feat: add support for custom email sender

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,8 @@ resource "aws_cognito_user_pool" "user_pool" {
       var.lambda_pre_sign_up,
       var.lambda_pre_token_generation,
       var.lambda_user_migration,
-      var.lambda_verify_auth_challenge_response
+      var.lambda_verify_auth_challenge_response,
+      var.lambda_custom_email_sender
     ), null) == null ? [] : [true]
 
     content {
@@ -149,6 +150,10 @@ resource "aws_cognito_user_pool" "user_pool" {
       pre_token_generation           = var.lambda_pre_token_generation
       user_migration                 = var.lambda_user_migration
       verify_auth_challenge_response = var.lambda_verify_auth_challenge_response
+      custom_email_sender {
+        lambda_arn                   = var.custom_email_sender.lambda_arn
+        lambda_version               = var.custom_email_sender.lambda_version
+      }
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -429,6 +429,15 @@ variable "lambda_verify_auth_challenge_response" {
   default     = null
 }
 
+variable "lambda_custom_email_sender" {
+  description = "(Optional) Configuration block for custom email sender Lambda triggers"
+  type = object({
+    lambda_arn     = string
+    lambda_version = string
+  })
+  default = null
+}
+
 variable "schema_attributes" {
   description = "(Optional) A list of schema attributes of a user pool. You can add a maximum of 25 custom attributes."
   type        = any


### PR DESCRIPTION
#### what.
 * Added support for the `custom_email_sender` property.

#### references.
* [terraform registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool#custom_email_sender-1)
